### PR TITLE
Don't install two Vims

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -63,7 +63,6 @@ brew "tfenv", link: false
 brew "timg"
 brew "tmux"
 brew "trash"
-brew "vim"
 brew "vmware-tanzu/carvel/ytt"
 brew "watch"
 brew "wget"


### PR DESCRIPTION
TL;DR
-----

Remove `vim` since `neovim` is installed

Details
-------

Realized that both `vim` and `neovim` brews were being installed,
which doesn't make a lot of sense since I alias `vim` to `neovim`.
This change removes `vim`.
